### PR TITLE
Add API versioning support

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,12 @@
+# API Versioning
+
+To the client side, API versioning is handled through content
+negotiation via the `Content-Type` header.
+
+Internally, we are using a custom routing middleware which parses
+the incoming `Content-Type` header, and depending on the requested
+version, dispatches to different versions of an API endpoint which
+is mounted internally on `/v1`, `/v2` prefixes.
+
+This allows us to expose a uniform external interface without
+polluting the URI.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "api-server",
-  "version": "0.1.0",
+  "name": "API-Server",
+  "version": "1.0.0",
   "description": "UCLCSSA API Server",
   "main": "src/index.js",
   "repository": "git@github.com:UCLCSSA/API-Server.git",
@@ -75,7 +75,8 @@
     "moment": "^2.24.0",
     "morgan": "^1.9.1",
     "mysql": "^2.17.1",
-    "rotating-file-stream": "^1.4.3"
+    "rotating-file-stream": "^1.4.3",
+    "semver": "^6.3.0"
   },
   "engines": {
     "node": ">=11"

--- a/src/auth/registration/helpers/find-user-session-by-open-id.js
+++ b/src/auth/registration/helpers/find-user-session-by-open-id.js
@@ -2,7 +2,7 @@ import debug from '../../../debug/debug';
 
 import { getPool } from '../../../persistence/db-connection';
 
-const findUserSession = wechatOpenId =>
+const findUserSessionByOpenId = wechatOpenId =>
   new Promise((resolve, reject) => {
     const pool = getPool();
 
@@ -55,4 +55,4 @@ const findUserSession = wechatOpenId =>
     pool.query(findUserSessionQuery, [wechatOpenId], handler);
   });
 
-export default findUserSession;
+export default findUserSessionByOpenId;

--- a/src/auth/registration/helpers/save-user-session.js
+++ b/src/auth/registration/helpers/save-user-session.js
@@ -1,6 +1,6 @@
 import currentDatetime from '../../../util/current-datetime-mysql';
 
-import findUserSession from './find-user-session';
+import findUserSessionByOpenId from './find-user-session-by-open-id';
 import updateUserSession from './update-user-session';
 import insertUserSession from './insert-user-session';
 
@@ -12,7 +12,7 @@ const saveUserSession =
     uclapiToken
   }) => {
     try {
-      const existingUserSession = await findUserSession(wechatOpenId);
+      const existingUserSession = await findUserSessionByOpenId(wechatOpenId);
 
       const creationDatetime = currentDatetime();
 

--- a/src/auth/registration/wechat-registration.handler.js
+++ b/src/auth/registration/wechat-registration.handler.js
@@ -48,6 +48,7 @@ const createWechatRegistrationHandler =
               if (!request.body) {
                 debug('Missing post body', { request, response, next });
                 handleMissingPostBody(response, next);
+                return;
               }
 
               const { appId, appSecret, code } = request.body;
@@ -56,6 +57,7 @@ const createWechatRegistrationHandler =
               if (!isNonEmptyStrings([appId, appSecret, code])) {
                 debug('Missing key', { appId, appSecret, code });
                 handleMissingKey(response, next);
+                return;
               }
 
               // Authenticate via WeChat Auth API
@@ -66,6 +68,7 @@ const createWechatRegistrationHandler =
               if (!wechatOpenId || !wechatSessionKey) {
                 debug('Failed to authenticate via WeChat API.');
                 handleWechatAuthenticatedFailed(response, next);
+                return;
               }
 
               // Generate a new uclcssaSessionKey based on WeChat openId and
@@ -78,6 +81,7 @@ const createWechatRegistrationHandler =
               if (!uclcssaSessionKey) {
                 debug('Failed to generate uclcssaSession.');
                 handleGenerateUclcssaSessionKeyFailed(response, next);
+                return;
               }
 
               const saveSuccess = await saveUserSession({
@@ -90,6 +94,7 @@ const createWechatRegistrationHandler =
               if (!saveSuccess) {
                 debug('Failed to save user session.');
                 handleSaveUserSessionFailed(response, next);
+                return;
               }
 
               // Return uclcssaSessionKey to the client. This session key shall

--- a/src/auth/registration/wechat-registration.handler.js
+++ b/src/auth/registration/wechat-registration.handler.js
@@ -87,8 +87,6 @@ const createWechatRegistrationHandler =
                 uclapiToken: ''
               });
 
-              console.log('WORLD');
-
               if (!saveSuccess) {
                 debug('Failed to save user session.');
                 handleSaveUserSessionFailed(response, next);

--- a/src/auth/registration/wechat-registration.handler.spec.js
+++ b/src/auth/registration/wechat-registration.handler.spec.js
@@ -52,8 +52,7 @@ describe('/register route handler', () => {
     expect(fakeNext.calledOnce).to.equal(true);
   });
 
-  it(
-    'should throw error for missing wechat auth handler',
+  it('should throw error for missing wechat auth handler',
     () => {
       expect(
         () => createWechatRegistrationHandler(null)(generator)(save)

--- a/src/debug/debugLogger.js
+++ b/src/debug/debugLogger.js
@@ -2,6 +2,8 @@ import debug from './debug';
 
 const debugLogger = (req, res, next) => {
   debug('=============================');
+  debug(`[PATH]: ${req.url}`);
+  debug('-----------------------------');
   debug('[REQUEST headers]');
   debug(req.headers);
   debug('[REQUEST body]');

--- a/src/util/http-content-type.js
+++ b/src/util/http-content-type.js
@@ -1,7 +1,9 @@
+import version from '../versioning/version';
+
 // See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type.
 const ContentType = {
   HTML_UTF8: 'text/html; charset=utf-8',
-  JSON: 'application/json'
+  JSON: `application/vnd.uclcssa.v${version.MAJOR}+json`
 };
 
 export default ContentType;

--- a/src/versioning/version.js
+++ b/src/versioning/version.js
@@ -1,0 +1,11 @@
+import semver from 'semver';
+
+import { version } from '../../package.json';
+
+const versionInfo = {
+  MAJOR: semver.major(version),
+  MINOR: semver.minor(version),
+  MAJOR_VERSION: semver.patch(version)
+};
+
+export default versionInfo;

--- a/src/versioning/versioning.dispatcher.js
+++ b/src/versioning/versioning.dispatcher.js
@@ -1,0 +1,60 @@
+import createBadRequestHandler from '../util/bad-request.handler';
+
+const handleInvalidVersion = createBadRequestHandler(
+  'Bad request: invalid API version specified.'
+);
+
+const rewritePath = (request, version, next) => {
+  request.url = `/v${version}` + request.originalUrl;
+  next();
+};
+
+/*
+ * This middleware modifies the request URL by prefixing a version before the
+ * path to delegate to a endpoint's handler of different versions, depending on
+ * the given Content-Type.
+ *
+ * For example, if the Content-Type header has the custom media type string
+ * `application/vnd.uclcssa.v1+json`, then if the path is `/logout`, it will
+ * become `/v1/logout` - where the v1 /logout route handler shall be mounted.
+ *
+ * If no Content-Type is supplied, by default the latest version is used.
+ *
+ * If an invalid Content-Type is supplied, a 400 Bad Request will be returned.
+ */
+const createVersioningDispatcher =
+  validMajorVersions => defaultMajorVersion => (request, response, next) => {
+  // If no Content-Type is specified, i.e. no version is specified, we shall
+  // use the default version and in JSON format.
+    if (!request.header('Content-Type')) {
+    // We rewrite the path to include a `/v1/` prefix.
+      rewritePath(request, defaultMajorVersion, next);
+      return;
+    }
+
+    // If there is a specified Content-Type, we try to parse it to extract the
+    // version information.
+    const contentType = request.header('Content-Type');
+
+    const versionedMediaTypeRegex =
+      /application\/vnd\.uclcssa\.v(?<version>\d+)\+json/;
+
+    const match = contentType.match(versionedMediaTypeRegex);
+
+    if (!match) {
+      rewritePath(request, defaultMajorVersion, next);
+      return;
+    }
+
+    const suppliedVersion = parseInt(match.groups.version, 10);
+
+    // If supplied version is a valid version, we write path accordingly.
+    // Otherwise, we return 400 Bad Request.
+    if (validMajorVersions.includes(suppliedVersion)) {
+      rewritePath(request, suppliedVersion, next);
+    } else {
+      handleInvalidVersion(response, next);
+    }
+  };
+
+export default createVersioningDispatcher;

--- a/src/versioning/versioning.dispatcher.spec.js
+++ b/src/versioning/versioning.dispatcher.spec.js
@@ -1,0 +1,80 @@
+import { describe, it, beforeEach } from 'mocha';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import HttpStatusCode from '../util/http-status-code';
+
+import createVersioningDispatcher from './versioning.dispatcher';
+
+describe('versioning dispatcher', () => {
+  let request;
+  let response;
+  let next;
+
+  const validMajorVersions = [1, 2];
+  const defaultMajorVersion = 1;
+  const expectedPrefix = `/v${defaultMajorVersion}`;
+
+  beforeEach(() => {
+    request = {
+      header: sinon.fake.returns(null),
+      originalUrl: '/hello'
+    };
+    response = {
+      status: sinon.fake(),
+      type: sinon.fake(),
+      json: sinon.fake()
+    };
+    next = sinon.fake();
+  });
+
+  it('should default to given major version if no Content-Type is specified',
+    () => {
+      const dispatcher =
+        createVersioningDispatcher(validMajorVersions)(defaultMajorVersion);
+
+      dispatcher(request, response, next);
+
+      expect(request.url).to.equal(`${expectedPrefix}/hello`);
+      expect(next.calledOnce).to.equal(true);
+    });
+
+  it('should extract given version number in Content-Type',
+    () => {
+      const dispatcher =
+        createVersioningDispatcher(validMajorVersions)(defaultMajorVersion);
+
+      request.header = sinon.fake.returns('application/vnd.uclcssa.v2+json');
+
+      dispatcher(request, response, next);
+
+      expect(request.url).to.equal(`/v2/hello`);
+      expect(next.calledOnce).to.equal(true);
+    });
+
+  it('should default to defaultMajorVersion if Content-Type does not specify',
+    () => {
+      const dispatcher =
+        createVersioningDispatcher(validMajorVersions)(defaultMajorVersion);
+
+      request.header = sinon.fake.returns('application/json');
+
+      dispatcher(request, response, next);
+
+      expect(request.url).to.equal(`/v1/hello`);
+      expect(next.calledOnce).to.equal(true);
+    });
+
+  it('should return 400 Bad Request if invalid version is given',
+    () => {
+      const dispatcher =
+        createVersioningDispatcher(validMajorVersions)(defaultMajorVersion);
+
+      request.header = sinon.fake.returns('application/vnd.uclcssa.v3+json');
+
+      dispatcher(request, response, next);
+
+      expect(response.status.calledWith(HttpStatusCode.BAD_REQUEST));
+      expect(next.calledOnce).to.equal(true);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4550,7 +4550,7 @@ semver-diff@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
-semver@^6.1.0, semver@^6.1.2:
+semver@^6.1.0, semver@^6.1.2, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==


### PR DESCRIPTION
API versioning support is handled on two fronts:

1. Client <-> API:

API versioning selection between client and API is handled through content negotiation via
the `Content-Type` header. A custom media type includes desired API version information
which is parsed by the API to determine which version of the endpoint handler to delegate
the request to.

A custom media type with version info looks like `application/vnd.uclcssa.v1+json`.

A typical request to the `v1` `/logout` handler would look like

```http
POST /logout HTTP/1.1
Content-Type: application/vnd.uclcssa.v1+json
Authorization: ABCDEFG
```

2. Internal

Internally, API versioning is handled by having the `versioningDispatcher` rewrite requests
based on client-supplied version information in the custom media type. Different version
of handlers may be mounted accordingly.

For instance, if there are two versions of the `/logout` handler, the `v1` handler would be 
mounted at `/v1/logout` and `v2` handler would be mounted at `/v2/logout`. To the client 
side, this is not visible and the client only sees the public facing `/logout` endpoint.
