### PR TITLE
Add logout

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "@types/chai-as-promised": "^7.1.1",
     "@types/convict": "^4.2.1",
     "@types/express": "^4.17.0",
+    "@types/mocha": "^5.2.7",
+    "@types/sinon": "^7.0.13",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "core-js": "^3.1.4",

--- a/src/auth/logout/helpers/clear-user-session.js
+++ b/src/auth/logout/helpers/clear-user-session.js
@@ -10,7 +10,8 @@ const clearUserSession = uclcssaSessionKey =>
       UPDATE UserSessions
       SET
         WechatSessionKey = '',
-        UclapiToken = ''
+        UclapiToken = '',
+        UclcssaSessionKey = ''
       WHERE
         UclcssaSessionKey = ?;
     `;

--- a/src/auth/logout/helpers/clear-user-session.js
+++ b/src/auth/logout/helpers/clear-user-session.js
@@ -1,0 +1,31 @@
+import debug from '../../../debug/debug';
+
+import { getPool } from '../../../persistence/db-connection';
+
+const clearUserSession = uclcssaSessionKey =>
+  new Promise((resolve, reject) => {
+    const pool = getPool();
+
+    const clearUserSessionQuery = `
+      UPDATE UserSessions
+      SET
+        WechatSessionKey = '',
+        UclapiToken = ''
+      WHERE
+        UclcssaSessionKey = ?;
+    `;
+
+    const handler = (error, result) => {
+      if (error) {
+        debug(error);
+        reject(error);
+      }
+
+      debug(`User session updated: ${result.affectedRows} affected rows`);
+      resolve();
+    };
+
+    pool.query(clearUserSessionQuery, [uclcssaSessionKey], handler);
+  });
+
+export default clearUserSession;

--- a/src/auth/logout/helpers/find-user-session-by-session-key.js
+++ b/src/auth/logout/helpers/find-user-session-by-session-key.js
@@ -1,0 +1,44 @@
+import debug from '../../../debug/debug';
+
+import { getPool } from '../../../persistence/db-connection';
+
+const findUserSessionBySessionKey = uclcssaSessionKey =>
+  new Promise((resolve, reject) => {
+    const pool = getPool();
+
+    const findUserSessionQuery = `
+      SELECT 
+        UclcssaSessionKey, 
+        WechatOpenId, 
+        WechatSessionKey, 
+        UclapiToken, 
+        CreationDatetime
+      FROM UserSessions
+      WHERE
+          UclcssaSessionKey = ?;
+    `;
+
+    const handler = (error, results) => {
+      if (error) {
+        debug('ERROR!');
+        debug(error);
+        reject(error);
+      }
+
+      resolve(() => {
+        // Try to find one matching record.
+        const [matchingUserSession] = results;
+
+        if (!matchingUserSession) {
+          debug('No matching user session found.');
+          return false;
+        }
+
+        return true;
+      });
+    };
+
+    pool.query(findUserSessionQuery, [uclcssaSessionKey], handler);
+  });
+
+export default findUserSessionBySessionKey;

--- a/src/auth/logout/logout.handler.js
+++ b/src/auth/logout/logout.handler.js
@@ -1,0 +1,55 @@
+import createBadRequestHandler from '../../util/bad-request.handler';
+import createAccessForbiddenHandler from '../../util/access-forbidden.handler';
+
+const handleMissingAuthorizationHeader = createBadRequestHandler(
+  'Bad request: missing Authorization header token.'
+);
+
+const handleInvalidSessionKey = createAccessForbiddenHandler(
+  'Access forbidden: invalid uclcssaSessionKey.'
+);
+
+const createLogoutHandler =
+  findUserSessionBySessionKey =>
+    clearUserSession => {
+      const missingDependencies =
+        () => !findUserSessionBySessionKey || !clearUserSession;
+
+      if (missingDependencies()) {
+        throw Error('Missing dependencies.');
+      }
+
+      return async (request, response, next) => {
+        try {
+          const sessionKey = request.header('Authorization');
+
+          // Missing Authorization header.
+          if (!sessionKey) {
+            handleMissingAuthorizationHeader(response, next);
+            return;
+          }
+
+          const sessionExists = await findUserSessionBySessionKey(sessionKey);
+
+          // If supplied uclcssaSessionKey does not exist in records, we return
+          // 403 Forbidden.
+          if (!sessionExists) {
+            handleInvalidSessionKey(response, next);
+            return;
+          }
+
+          // We clear associated wechat sessionKey and uclapi token with the
+          // given uclcssaSessionKey. This invalidates the user session.
+          await clearUserSession(sessionKey);
+
+          // We simply send 200 OK if logging out is successful.
+          response.status(200);
+          response.end();
+          next();
+        } catch (error) {
+          next(error);
+        }
+      };
+    };
+
+export default createLogoutHandler;

--- a/src/auth/logout/logout.handler.spec.js
+++ b/src/auth/logout/logout.handler.spec.js
@@ -1,0 +1,108 @@
+import { expect } from 'chai';
+import { describe, beforeEach, it } from 'mocha';
+import sinon from 'sinon';
+
+import HttpStatusCode from '../../util/http-status-code';
+import ContentType from '../../util/http-content-type';
+
+import createLogoutHandler from './logout.handler';
+
+describe('/logout route handler', () => {
+  let fakeRequest;
+  let fakeResponse;
+  let fakeNext;
+  let findUserSession;
+  let clearUserSession;
+  let handler;
+
+  beforeEach(() => {
+    fakeRequest = {
+      header: sinon.fake.returns(null)
+    };
+    fakeResponse = {
+      status: sinon.fake(),
+      type: sinon.fake(),
+      json: sinon.fake()
+    };
+    fakeNext = sinon.fake();
+    findUserSession = sinon.fake.resolves(false);
+    clearUserSession = sinon.fake.resolves(null);
+    handler = createLogoutHandler(findUserSession)(clearUserSession);
+  });
+
+  it('should return 400 bad request for missing Authorization header',
+    async () => {
+      await handler(fakeRequest, fakeResponse, fakeNext);
+
+      expect(fakeResponse.status.calledWith(HttpStatusCode.BAD_REQUEST))
+        .to.equal(true);
+      expect(fakeResponse.type.calledWith(ContentType.JSON)).to.equal(true);
+      expect(fakeNext.calledOnce).to.equal(true);
+    });
+
+  it('should throw error for missing findUserSession dependency',
+    () => {
+      expect(
+        () => createLogoutHandler(null)(clearUserSession)
+      ).to.throw();
+    });
+
+  it('should throw error for missing clearUserSession dependency',
+    () => {
+      expect(
+        () => createLogoutHandler(findUserSession)(null)
+      ).to.throw();
+    });
+
+  it('should return 403 forbidden for non-existent user session',
+    async () => {
+      fakeRequest = {
+        header: sinon.fake.returns('Some-UclcssaSessionKey')
+      };
+
+      findUserSession = sinon.fake.resolves(false);
+
+      handler = createLogoutHandler(findUserSession)(clearUserSession);
+
+      await handler(fakeRequest, fakeResponse, fakeNext);
+
+      expect(fakeResponse.status.calledWith(HttpStatusCode.FORBIDDEN))
+        .to.equal(true);
+      expect(fakeResponse.type.calledWith(ContentType.JSON)).to.equal(true);
+      expect(fakeNext.calledOnce).to.equal(true);
+    });
+
+  it('should call clearUserSession if User Session exists',
+    async () => {
+      fakeRequest = {
+        header: sinon.fake.returns('Some-UclcssaSessionKey')
+      };
+
+      findUserSession = sinon.fake.resolves(true);
+      clearUserSession = sinon.fake.resolves(null);
+
+      handler = createLogoutHandler(findUserSession)(clearUserSession);
+
+      await handler(fakeRequest, fakeResponse, fakeNext);
+
+      expect(clearUserSession.calledOnce).to.equal(true);
+    });
+
+  it('should return 200 OK if User Session is successfully cleared',
+    async () => {
+      fakeRequest = {
+        header: sinon.fake.returns('Some-UclcssaSessionKey')
+      };
+
+      findUserSession = sinon.fake.resolves(true);
+      clearUserSession = sinon.fake.resolves(null);
+
+      handler = createLogoutHandler(findUserSession)(clearUserSession);
+
+      await handler(fakeRequest, fakeResponse, fakeNext);
+
+      expect(fakeResponse.status.calledWith(HttpStatusCode.OK))
+        .to.equal(true);
+      expect(fakeNext.calledOnce).to.equal(true);
+    });
+});

--- a/src/auth/logout/logout.router.js
+++ b/src/auth/logout/logout.router.js
@@ -1,0 +1,16 @@
+import express from 'express';
+
+import createLogoutHandler from './logout.handler';
+
+import findUserSessionBySessionKey
+  from './helpers/find-user-session-by-session-key';
+import clearUserSession from './helpers/clear-user-session';
+
+const logoutRouter = express.Router();
+
+const logoutHandler =
+  createLogoutHandler(findUserSessionBySessionKey)(clearUserSession);
+
+logoutRouter.post('/logout', logoutHandler);
+
+export default logoutRouter;

--- a/src/auth/registration/wechat-registration.handler.spec.js
+++ b/src/auth/registration/wechat-registration.handler.spec.js
@@ -7,7 +7,7 @@ import ContentType from '../../util/http-content-type';
 
 import createWechatRegistrationHandler from './wechat-registration.handler';
 
-describe('/register route handler', () => {
+describe('/register/wechat route handler', () => {
   let body;
   let fakeRes;
   let fakeNext;

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,7 @@ import createVersioningDispatcher from './versioning/versioning.dispatcher';
 import version from './versioning/version';
 
 import registrationRouter from './auth/registration/registration.router';
+import logoutRouter from './auth/logout/logout.router';
 
 const app = express();
 
@@ -71,7 +72,9 @@ app.use(logger);
 
 /// Routes
 
+// Authentication and authorization
 app.use('/v1', registrationRouter);
+app.use('/v1', logoutRouter);
 
 // The port the server is to listen on. Defaults to 3000.
 const port = config.get('port');

--- a/src/util/access-forbidden.handler.js
+++ b/src/util/access-forbidden.handler.js
@@ -1,0 +1,8 @@
+import createErrorHandler from './generic-error.handler';
+
+import HttpStatusCode from './http-status-code';
+
+const createAccessForbiddenHandler =
+  createErrorHandler(HttpStatusCode.FORBIDDEN);
+
+export default createAccessForbiddenHandler;

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,6 +834,11 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
+"@types/mocha@^5.2.7":
+  version "5.2.7"
+  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-5.2.7.tgz#315d570ccb56c53452ff8638738df60726d5b6ea"
+  integrity sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==
+
 "@types/node@*":
   version "12.6.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.6.8.tgz#e469b4bf9d1c9832aee4907ba8a051494357c12c"
@@ -856,6 +861,11 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/sinon@^7.0.13":
+  version "7.0.13"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-7.0.13.tgz#ca039c23a9e27ebea53e0901ef928ea2a1a6d313"
+  integrity sha512-d7c/C/+H/knZ3L8/cxhicHUiTDxdgap0b/aNJfsmLwFu/iOP17mdgbQsbHA3SJmrzsjD0l3UEE5SN4xxuz5ung==
 
 abbrev@1:
   version "1.1.1"


### PR DESCRIPTION
Adds logout support at `/logout`, where it:

- Invalidates a user's `uclcssaSessionKey`
- Invalidates a user's WeChat `sessionKey`
- Invalidates a user's UCLAPI `token`

Upon logging out, the user must go through the registration steps again.